### PR TITLE
Fix checkout pos total and add monthly history

### DIFF
--- a/src/lib/services/cassa.ts
+++ b/src/lib/services/cassa.ts
@@ -136,7 +136,7 @@ export async function getStatoCassaCompleto(data: string): Promise<StatoCassa> {
       .reduce((sum, m) => sum + m.importo, 0);
     
 
-    const venditeCarti = fondoCassa?.vendite_carta || totalePOS;
+    const venditeCarta = Math.max(Number(fondoCassa?.vendite_carta ?? 0), totalePOS);
     const altreEntrate = fondoCassa?.altre_entrate || 0;
     const fondoTeorico = fondoIniziale + venditeContanti + altreEntrate - uscite;
 
@@ -145,7 +145,7 @@ export async function getStatoCassaCompleto(data: string): Promise<StatoCassa> {
       aperta: !fondoCassa?.chiuso,
       fondo_iniziale: fondoIniziale,
       vendite_contanti: venditeContanti,
-      vendite_carta: venditeCarti,
+      vendite_carta: venditeCarta,
       altre_entrate: altreEntrate,
       uscite,
       fondo_teorico: fondoTeorico,


### PR DESCRIPTION
Include POS payments in cassa totals and add a monthly view to the storico tab.

The user requested that POS payments be accounted for in the cassa totals and that the storico tab provide a monthly history view in addition to the daily view.

---
<a href="https://cursor.com/background-agent?bcId=bc-b878eabf-c096-42bb-a920-75074bc7384d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b878eabf-c096-42bb-a920-75074bc7384d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

